### PR TITLE
✨ [유경] feat : post페이지 API연동 및 디자인 수정

### DIFF
--- a/src/api/createRollingPaper.js
+++ b/src/api/createRollingPaper.js
@@ -1,0 +1,18 @@
+const BASE_URL = 'https://rolling-api.vercel.app/{4}-{10}/';
+
+export async function createRollingPaper(body) {
+  const res = await fetch(`${BASE_URL}recipients/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    throw new Error('롤링페이퍼를 생성하는데 실패하였습니다.');
+  }
+
+  const data = await res.json();
+  return data;
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,11 +1,13 @@
 import styled from 'styled-components';
 import COLORS from '../utils/colors';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import logoImg from '../assets/rolling_Logo.svg';
 import Layout from '../layout/Layout';
 import Buttons from './Buttons';
 
 const Navbar = () => {
+  const currentLocation = useLocation();
+
   return (
     <Nav>
       <Layout>
@@ -19,7 +21,11 @@ const Navbar = () => {
               </Link>
             </li>
             <li>
-              <Buttons buttonType="Outlined40">롤링 페이퍼 만들기</Buttons>
+              {currentLocation.pathname !== '/post' && (
+                <Link to="/post">
+                  <Buttons buttonType="Outlined40">롤링 페이퍼 만들기</Buttons>
+                </Link>
+              )}
             </li>
           </Ul>
         </Container>

--- a/src/pages/PostPage/Post.jsx
+++ b/src/pages/PostPage/Post.jsx
@@ -123,11 +123,6 @@ const SelectButton = styled.button`
   background-color: ${({ isBgType }) => (isBgType === true ? COLORS.white : COLORS.gray100)};
   border: 0.2rem solid ${({ isBgType }) => (isBgType === true ? COLORS.purple700 : COLORS.gray100)};
 
-  &:hover {
-    background-color: ${COLORS.gray200};
-    border: 0.2rem solid ${COLORS.gray200};
-  }
-
   &:focus {
     background-color: ${COLORS.white};
     border: 0.2rem solid ${COLORS.purple700};

--- a/src/pages/PostPage/Post.jsx
+++ b/src/pages/PostPage/Post.jsx
@@ -2,13 +2,37 @@ import styled from 'styled-components';
 import COLORS from '../../utils/colors';
 import FONTS from '../../utils/Fonts';
 import Buttons from '../../components/Buttons';
-import { useState } from 'react';
-import BackgroundOption from './component/BackgroundOption/BackgroundOption.jsx';
+import { useEffect, useState } from 'react';
+import { COLOR_OPTION } from './component/BackgroundOption/constant.js';
+import checkIcon from '../../assets/icons/check.svg';
+import { getBackgroundImageURL } from '../../api/getBackgroundImageURL.js';
+import { createRollingPaper } from '../../api/createRollingPaper.js';
+import { useNavigate } from 'react-router-dom';
 
 const Post = () => {
+  const [backgroundImgData, setBackgroundImgData] = useState();
+  const [SelectedColor, setSelectedColor] = useState(0);
+  const [SelectedImage, setSelectedImage] = useState(0);
   const [inputValue, setInputValue] = useState();
   const [isEmptyError, setIsEmptyError] = useState(false);
   const [backgroundType, setBackgroundType] = useState('color');
+  const navigate = useNavigate();
+
+  const handleLoadBackgroundImgURL = async () => {
+    const data = await getBackgroundImageURL();
+    setBackgroundImgData(data.imageUrls);
+  };
+
+  const handleSelectedColor = (e) => {
+    e.preventDefault();
+    setSelectedColor(+e.target.id);
+  };
+
+  const handleSelectedImage = (e) => {
+    e.preventDefault();
+    setSelectedImage(+e.target.id);
+  };
+  ///
 
   const handleInputValue = (e) => {
     setInputValue(e.target.value);
@@ -22,8 +46,35 @@ const Post = () => {
   const handleBackgroundType = (e) => {
     setBackgroundType(e.target.name);
   };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    const BgColor = {
+      orange200: 'beige',
+      purple200: 'purple',
+      blue200: 'blue',
+      green200: 'green',
+    };
+
+    const body = {
+      team: '10',
+      name: inputValue,
+      backgroundColor: BgColor[COLOR_OPTION[SelectedColor]],
+      backgroundImageURL: backgroundType === 'image' ? backgroundImgData[SelectedImage] : null,
+    };
+
+    const { id } = await createRollingPaper(body);
+    console.log(id);
+    navigate(`/post/${id}`);
+  };
+
+  useEffect(() => {
+    handleLoadBackgroundImgURL();
+  }, []);
+
   return (
-    <PostLayout>
+    <PostLayout onSubmit={handleSubmit}>
       <SendToInputContainer>
         <MainDescription>To.</MainDescription>
         <InputBox
@@ -59,15 +110,42 @@ const Post = () => {
           이미지
         </SelectButton>
       </ToggleButtons>
-      <BackgroundOption backgroundType={backgroundType} />
-      <Buttons buttonType="Primary56" buttonSize="large" isDisabled={isEmptyError}>
+      {backgroundType === 'color' ? (
+        <ColorBoxContainer>
+          {COLOR_OPTION.map((color, index) => (
+            <BackgroundColor backgroundColor={color} key={index} id={index} onClick={handleSelectedColor}>
+              {index === SelectedColor && (
+                <CheckMark>
+                  <img src={checkIcon} alt="checkIcon" />
+                </CheckMark>
+              )}
+            </BackgroundColor>
+          ))}
+        </ColorBoxContainer>
+      ) : (
+        <ImageBoxContainer>
+          {backgroundImgData.map((url, index) => (
+            <BackgroundImage backgroundImageURL={url} key={index} id={index} onClick={handleSelectedImage}>
+              {index === SelectedImage && (
+                <>
+                  <CheckMark>
+                    <img src={checkIcon} alt="checkIcon" />
+                  </CheckMark>
+                  <SelectImageCover />
+                </>
+              )}
+            </BackgroundImage>
+          ))}
+        </ImageBoxContainer>
+      )}
+      <Buttons buttonType="Primary56" buttonSize="large" isDisabled={isEmptyError} onClick={handleSubmit}>
         생성하기
       </Buttons>
     </PostLayout>
   );
 };
 
-const PostLayout = styled.div`
+const PostLayout = styled.form`
   padding-top: 6rem;
   display: inline-flex;
   flex-direction: column;
@@ -135,6 +213,54 @@ const ErrorMessage = styled.p`
   ${FONTS.font12_Regular}
   color: ${COLORS.error};
   visibility: ${({ isEmptyError }) => (isEmptyError ? 'visible' : 'hidden')};
+`;
+
+///
+
+const CheckMark = styled.div`
+  padding: 1rem;
+  background-color: ${COLORS.gray500};
+  border-radius: 50%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1;
+`;
+
+const ColorBoxContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.6rem;
+`;
+
+const ImageBoxContainer = styled(ColorBoxContainer)``;
+
+export const BackgroundOptionBox = styled.button`
+  width: 16.8rem;
+  height: 16.8rem;
+  border-radius: 1.6rem;
+  cursor: pointer;
+`;
+
+export const BackgroundColor = styled(BackgroundOptionBox)`
+  background-color: ${({ backgroundColor }) => COLORS[backgroundColor]};
+  position: relative;
+`;
+
+export const BackgroundImage = styled(BackgroundOptionBox)`
+  background-image: url(${(props) => props.backgroundImageURL});
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+  position: relative;
+`;
+
+export const SelectImageCover = styled(BackgroundColor)`
+  background-color: white;
+  opacity: 0.2;
 `;
 
 export default Post;

--- a/src/pages/PostPage/component/BackgroundOption/BackgroundOption.jsx
+++ b/src/pages/PostPage/component/BackgroundOption/BackgroundOption.jsx
@@ -48,9 +48,12 @@ const BackgroundOption = ({ backgroundType }) => {
           {backgroundImgData.map((url, index) => (
             <BackgroundImage backgroundImageURL={url} key={index} id={index} onClick={handleSelectedImage}>
               {index === SelectedImage && (
-                <CheckMark>
-                  <img src={checkIcon} alt="checkIcon" />
-                </CheckMark>
+                <>
+                  <CheckMark>
+                    <img src={checkIcon} alt="checkIcon" />
+                  </CheckMark>
+                  <SelectImageCover />
+                </>
               )}
             </BackgroundImage>
           ))}
@@ -69,6 +72,7 @@ const CheckMark = styled.div`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  z-index: 1;
 `;
 
 const ColorBoxContainer = styled.div`
@@ -100,4 +104,10 @@ export const BackgroundImage = styled(BackgroundOptionBox)`
   background-size: cover;
   position: relative;
 `;
+
+export const SelectImageCover = styled(BackgroundColor)`
+  background-color: white;
+  opacity: 0.2;
+`;
+
 export default BackgroundOption;

--- a/src/pages/PostPage/component/BackgroundOption/BackgroundOption.jsx
+++ b/src/pages/PostPage/component/BackgroundOption/BackgroundOption.jsx
@@ -97,6 +97,7 @@ export const BackgroundImage = styled(BackgroundOptionBox)`
   background-image: url(${(props) => props.backgroundImageURL});
   background-repeat: no-repeat;
   background-position: center;
+  background-size: cover;
   position: relative;
 `;
 export default BackgroundOption;


### PR DESCRIPTION
## 작업 주제
- [ ] UI추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정

## 구현 사항 설명
- post페이지에서 입력한 정보를 담아 롤링페이퍼 만들기 기능 추가
- useLocation을 사용하여, 현재 접속한 페이지의 주소가 post인 경우 nav바의 롤링페이퍼 만들기 버튼이 보이지 않게 함
- 배경 유형 중 이미지의 경우, 선택된 이미지 위에 흰바탕이 반투명하게 깔리면서 보다 명확하게 선택되게끔 함
- 롤링페이퍼가 성공적으로 만들어진 경우, 생성하기 버튼을 눌렀을 때 생성된 롤링페이퍼로 이동될 수 있도록 함

## 스크린샷 or 배포링크
### 기본 nav 바
![post 이외의 페이지에서 nav 바](https://github.com/sprint4-team10/Rolling/assets/153581513/8e6229bb-9740-4442-aa82-d0fa370fb6fc)

### post 페이지에서의 nav 바
![post 페이지에서 nav 바](https://github.com/sprint4-team10/Rolling/assets/153581513/13d9fdaf-98bf-448e-9032-22e4d8188bbc)

### post페이지 동작 예시
![ezgif-6-c382436946](https://github.com/sprint4-team10/Rolling/assets/153581513/567b6e1f-ff57-4891-8aa5-4a957b37d1ca)



## 성장포인트 & 보완할 점
- 이미지를 불러올 때, 로딩 중임을 알 수 있게 하기
- 여전히 disabled일 때 hover 되는 문제를 해결하지 못함
- 기본값이 disabled로 바꿔야될 것 같음 (처음 페이지가 로드되었을 때는 아무 값도 입력되지 않았기 때문에)
- 코드가 너무 지저분하고 분리도 되지 않아서, 리팩토링이 대대적으로 필요해보인다.

