### PR TITLE
:bug: [태진] fix: Senders 컴포넌트 마지막 ProfileList 너비 수정

### DIFF
--- a/src/components/Senders/index.jsx
+++ b/src/components/Senders/index.jsx
@@ -48,6 +48,8 @@ const Item = styled.li`
   justify-content: center;
   align-items: center;
   &:last-child {
+    width: auto;
+    padding: 0 7px;
     border: 1px solid ${COLORS.gray300};
   }
   &:not(:last-child) {


### PR DESCRIPTION
## 작업 주제

- [ ] UI추가
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정

## 구현 사항 설명
아래 스크린샷과 같이 숫자가 커지더라도 삐져나오지 않도록 수정

## 스크린샷 or 배포링크
<img width="199" alt="image" src="https://github.com/sprint4-team10/Rolling/assets/60560836/d7b09c45-4d14-4f7f-bd32-6e518da944da">

## 성장포인트 & 보완할 점

멘토링이 아니었으면 생각 못했을 문제였다. 앞으로 비슷한 상황이 생긴다면 지금과 같은 문제를 고려하여 코드를 작성할 것이다