### PR TITLE
♻️[유경] refactor : Button 컴포넌트 반응형 추가

### DIFF
--- a/src/components/Buttons/Buttons.jsx
+++ b/src/components/Buttons/Buttons.jsx
@@ -1,40 +1,76 @@
 import { Outlined36, Outlined40, Outlined56, Primary40, Primary56, Secondary40 } from './ButtonsStyled';
 
-const Buttons = ({ onClick, children, buttonType, buttonSize, isDisabled }) => {
+const Buttons = ({ onClick, children, buttonType, buttonSize, mobileButtonSize, tabletButtonSize, isDisabled }) => {
   switch (buttonType) {
     case 'Primary56':
       return (
-        <Primary56 onClick={onClick} buttonSize={buttonSize} disabled={isDisabled}>
+        <Primary56
+          onClick={onClick}
+          buttonSize={buttonSize}
+          mobileButtonSize={mobileButtonSize}
+          tabletButtonSize={tabletButtonSize}
+          disabled={isDisabled}
+        >
           {children}
         </Primary56>
       );
     case 'Primary40':
       return (
-        <Primary40 onClick={onClick} buttonSize={buttonSize} disabled={isDisabled}>
+        <Primary40
+          onClick={onClick}
+          buttonSize={buttonSize}
+          mobileButtonSize={mobileButtonSize}
+          tabletButtonSize={tabletButtonSize}
+          disabled={isDisabled}
+        >
           {children}
         </Primary40>
       );
     case 'Secondary40':
       return (
-        <Secondary40 onClick={onClick} buttonSize={buttonSize} disabled={isDisabled}>
+        <Secondary40
+          onClick={onClick}
+          buttonSize={buttonSize}
+          mobileButtonSize={mobileButtonSize}
+          tabletButtonSize={tabletButtonSize}
+          disabled={isDisabled}
+        >
           {children}
         </Secondary40>
       );
     case 'Outlined56':
       return (
-        <Outlined56 onClick={onClick} buttonSize={buttonSize} disabled={isDisabled}>
+        <Outlined56
+          onClick={onClick}
+          buttonSize={buttonSize}
+          mobileButtonSize={mobileButtonSize}
+          tabletButtonSize={tabletButtonSize}
+          disabled={isDisabled}
+        >
           {children}
         </Outlined56>
       );
     case 'Outlined40':
       return (
-        <Outlined40 onClick={onClick} buttonSize={buttonSize} isDisabled={isDisabled}>
+        <Outlined40
+          onClick={onClick}
+          buttonSize={buttonSize}
+          mobileButtonSize={mobileButtonSize}
+          tabletButtonSize={tabletButtonSize}
+          isDisabled={isDisabled}
+        >
           {children}
         </Outlined40>
       );
     case 'Outlined36':
       return (
-        <Outlined36 onClick={onClick} buttonSize={buttonSize} isDisabled={isDisabled}>
+        <Outlined36
+          onClick={onClick}
+          buttonSize={buttonSize}
+          mobileButtonSize={mobileButtonSize}
+          tabletButtonSize={tabletButtonSize}
+          isDisabled={isDisabled}
+        >
           {children}
         </Outlined36>
       );

--- a/src/components/Buttons/ButtonsStyled.js
+++ b/src/components/Buttons/ButtonsStyled.js
@@ -3,10 +3,11 @@ import FONTS from '../../utils/Fonts';
 import COLORS from '../../utils/colors';
 
 const BUTTON_SIZE = {
-  large: 72,
-  medium: 32,
-  small: 28,
-  xSmall: 12,
+  large: `72rem`,
+  medium: `32rem`,
+  small: `28rem`,
+  xSmall: `12rem`,
+  full: '95vw',
 };
 
 export const Primary56 = styled.button`
@@ -16,7 +17,7 @@ export const Primary56 = styled.button`
   padding: 1.4rem 2.4rem;
   border-radius: 1.2rem;
   background-color: ${COLORS.purple600};
-  width: ${({ buttonSize }) => BUTTON_SIZE[buttonSize]}rem;
+  width: ${({ buttonSize }) => BUTTON_SIZE[buttonSize]};
   border: 0.2rem solid ${COLORS.purple600};
 
   &:disabled {
@@ -38,6 +39,14 @@ export const Primary56 = styled.button`
     &:focus {
       background-color: ${COLORS.purple800};
       border: 0.2rem solid ${COLORS.purple900};
+    }
+
+    @media (max-width: 1199px) {
+      width: ${({ tabletButtonSize }) => BUTTON_SIZE[tabletButtonSize]};
+    }
+
+    @media (max-width: 767px) {
+      width: ${({ mobileButtonSize }) => BUTTON_SIZE[mobileButtonSize]};
     }
   }
 `;

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -38,7 +38,7 @@ const Main = () => {
         </Section>
         <div style={{ width: 'fit-content', margin: '0 auto' }}>
           <Link to="/list">
-            <Buttons buttonType="Primary56" buttonSize="small">
+            <Buttons buttonType="Primary56" buttonSize="small" tabletButtonSize="full">
               구경해보기
             </Buttons>
           </Link>


### PR DESCRIPTION
## 작업 주제
- [ ] UI추가
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정

## 구현 사항 설명
: 버튼이 타블렛 및 모바일에서 유동적으로 움직이지 않는 점 해결
: 화면에 꽉차는 버튼을 원하는 경우 추가
: 타블렛에서 버튼이 화면에 꽉차게 할 것인지, 고정 크기로 유지할 것인지 선택할 수 있게 함

## 스크린샷 or 배포링크
```js
<Buttons buttonType="Primary56" buttonSize="small" tabletButtonSize="full">
    구경해보기
</Buttons>
```
### PC화면
![스크린샷 2024-03-04 171548](https://github.com/sprint4-team10/Rolling/assets/153581513/b9b7908c-ed33-4c4c-aeac-d944e3c55abd)
### 타블렛 화면
![스크린샷 2024-03-04 171610](https://github.com/sprint4-team10/Rolling/assets/153581513/db524f4e-04f2-4523-9242-2aa5369a7318)


## 성장포인트 & 보완할 점
- prop으로 모바일 화면 크기와 타블렛 화면 크기를 모두 지정해줄 수 있게 하긴 했지만, 사용성이 나빠진 것 같아서 조금 아쉽다. 그렇다고 반응형일 때 모두 화면에 채워지도록 하는 것은 좋지 않은 방법 같다.
- 그리고, 꽉 채우는 것을 100%로 안하고, 95vw으로 했는데, 다른 더 좋은 방법이 있지 않을까 생각이 든다.