### PR TITLE
✨ [유경] feat : post페이지 리퀘스트 중복 요청 방지

### DIFF
--- a/src/pages/PostPage/Post.jsx
+++ b/src/pages/PostPage/Post.jsx
@@ -16,6 +16,7 @@ const Post = () => {
   const [inputValue, setInputValue] = useState();
   const [isEmptyError, setIsEmptyError] = useState(true);
   const [backgroundType, setBackgroundType] = useState('color');
+  const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
 
   const handleLoadBackgroundImgURL = async () => {
@@ -60,9 +61,15 @@ const Post = () => {
       backgroundColor: BgColor[COLOR_OPTION[selectBackgroundType.color]],
       backgroundImageURL: backgroundType === 'image' ? backgroundImgData[selectBackgroundType.image] : null,
     };
-
-    const { id } = await createRollingPaper(body);
-    navigate(`/post/${id}`);
+    try {
+      setIsLoading(true);
+      const { id } = await createRollingPaper(body);
+      navigate(`/post/${id}`);
+    } catch (error) {
+      return;
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   useEffect(() => {
@@ -128,7 +135,7 @@ const Post = () => {
           ))}
         </S.ImageBoxContainer>
       )}
-      <Buttons buttonType="Primary56" buttonSize="large" isDisabled={isEmptyError} onClick={handleSubmit}>
+      <Buttons buttonType="Primary56" buttonSize="large" isDisabled={isEmptyError || isLoading} onClick={handleSubmit}>
         생성하기
       </Buttons>
     </S.PostLayout>


### PR DESCRIPTION
## 작업 주제
- [ ] UI추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정

## 구현 사항 설명
: 원활하지 않은 네트워크 환경에서 롤링페이퍼를 생성했을 때 동일한 내용의 리퀘스트를 여러 번 보낼 수 있었음
-> 리퀘스트가 동작 중일 때는 버튼이 disabled 되면서 리퀘스트를 여러 번 보내지 못하도록 함

## 스크린샷 or 배포링크
### Slow 3G일 때
![스크린샷 2024-03-05 154348](https://github.com/sprint4-team10/Rolling/assets/153581513/97d123ed-54e6-4081-a5be-2bdbad5cde0c)


## 성장포인트 & 보완할 점
: 리퀘스트를 보내는 중일 때를 어떻게 접근 해야 할 지 몰랐는데, 이렇게 접근할 수도 있다는 것을 알았다.
: 로딩 처리를 위한 방법 중 하나를 알게 된 것 같아서 기쁘다!!!