### PR TITLE
🐛 [승아]: Post 페이지 CSS 값 수정

### DIFF
--- a/src/components/Buttons/ButtonsStyled.js
+++ b/src/components/Buttons/ButtonsStyled.js
@@ -20,6 +20,7 @@ export const Primary56 = styled.button`
   width: ${({ buttonSize }) => BUTTON_SIZE[buttonSize]};
   border: 0.2rem solid ${COLORS.purple600};
   max-width: 72rem;
+  width: 100%;
 
   &:disabled {
     background-color: ${COLORS.gray300};

--- a/src/pages/PostPage/PostStyled.js
+++ b/src/pages/PostPage/PostStyled.js
@@ -10,14 +10,14 @@ const BACKGROUND_COLOR = {
 };
 
 export const PostLayout = styled.form`
-  padding-top: 6rem;
+  padding-top: 2rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
-  gap: 4rem;
+  gap: 3rem;
   max-width: 72rem;
-  width: calc(-9.6rem + 100vw);
+  width: calc(-4.6rem + 100vw);
   margin: 2rem auto;
 `;
 


### PR DESCRIPTION
## 작업 주제

- [ ] UI추가
- [ ] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정

## 구현 사항 설명
화면이 줄어들었을 때
마진이 너무 남아서 페이지가 텅텅 비어보이는 부분 수정
padding-top 값을 줄이고 gap 값을 줄여서 간격 좁힘

## 스크린샷 or 배포링크
![image](https://github.com/sprint4-team10/Rolling/assets/155128712/3fca1a24-0157-49f7-b8a8-bd2f1ef50909)

## 성장포인트 & 보완할 점
헤헤.. 심미적인 부분은 아직 잘 캐치하지 못하겠네요
